### PR TITLE
Task: CSS Bayan

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Document</title>
+</head>
+<body>
+        
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,34 +9,36 @@
 </head>
 <body>
         <div class="accordion_wrapper">
+                <div class="accordion_hover">
                 <h1 class="h1">CSS Bayan</h1>
                 <span class="line"></span>
                 <div class="accordion_element" id="aElement1">
-                        <a class="accordion_text" href="#aElement1">Developer Tester Client<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
-                        <span class="line"></span>
-                        <img src="https://media.tenor.com/DsbHvWBb6VgAAAAC/programming-client.gif" alt="picture" alt="picture" width="300" height="250" class="img">
+                        <a class="accordion_text" href="#aElement1">Developer Tester Client<div class="plus"><span class="lineUP" ></span><span class="lineDown" ></span></div></a>
+                        <img src="https://media.tenor.com/DsbHvWBb6VgAAAAC/programming-client.gif" alt="picture" alt="picture" class="img">
                 </div>
+                <span class="line"></span>
                 <div class="accordion_element" id="aElement2">
                         <a class="accordion_text" href="#aElement2">Programmer Bug<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
-                        <span class="line"></span>
-                        <img src="https://media.tenor.com/w_mnvc7ulu8AAAAM/scaler-create-impact.gif" alt="picture" width="300" height="250" class="img">
+                        <img src="https://media.tenor.com/w_mnvc7ulu8AAAAM/scaler-create-impact.gif" alt="picture" class="img">
 
                 </div>
+                <span class="line"></span>
                 <div class="accordion_element" id="aElement3">
-                        <a class="accordion_text" href="#aElement3">CSS<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
-                        <span class="line"></span>
-                        <img src="https://media.tenor.com/57w9du3NrV0AAAAM/css-html.gif" alt="picture" alt="picture" width="300" height="250" class="img">
+                        <a class="accordion_text" href="#aElement3">CSS<div class="plus"><span class="lineUP" id="up"></span><span class="lineDown" id="down"></span></div></a>
+                        <img src="https://media.tenor.com/57w9du3NrV0AAAAM/css-html.gif" alt="picture" alt="picture" class="img">
                 </div>
+                <span class="line"></span>
                 <div class="accordion_element" id="aElement4">
                         <a class="accordion_text" href="#aElement4">QA Developer Designer<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
-                        <span class="line"></span>
-                        <img src="https://media.tenor.com/CD5CJb7w_4IAAAAM/qa-smash.gif" alt="picture" width="300" height="250" class="img">
+                        <img src="https://media.tenor.com/CD5CJb7w_4IAAAAM/qa-smash.gif" alt="picture" class="img">
                 </div>
+                <span class="line"></span>
                 <div class="accordion_element" id="aElement5">
                         <a class="accordion_text" href="#aElement5">Senior Junior<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
-                        <span class="line"></span>
-                        <img src="https://media.tenor.com/7urvfYVarZYAAAAM/senior2junior-throwstone.gif" alt="picture" width="300" height="250" class="img">
+                        <img src="https://media.tenor.com/7urvfYVarZYAAAAM/senior2junior-throwstone.gif" alt="picture" class="img">
                 </div>
+                <span class="line"></span>
         </div>
+</div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,29 +11,29 @@
         <div class="accordion_wrapper">
                 <h1 class="h1">CSS Bayan</h1>
                 <span class="line"></span>
-                <div class="accordion_element" id="test1">
-                        <a class="accordion_text" href="#test1">Developer Tester Client<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
+                <div class="accordion_element" id="aElement1">
+                        <a class="accordion_text" href="#aElement1">Developer Tester Client<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
                         <span class="line"></span>
                         <img src="https://media.tenor.com/DsbHvWBb6VgAAAAC/programming-client.gif" alt="picture" alt="picture" width="300" height="250" class="img">
                 </div>
-                <div class="accordion_element" id="test2">
-                        <a class="accordion_text" href="#test2">Programmer Bug<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
+                <div class="accordion_element" id="aElement2">
+                        <a class="accordion_text" href="#aElement2">Programmer Bug<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
                         <span class="line"></span>
                         <img src="https://media.tenor.com/w_mnvc7ulu8AAAAM/scaler-create-impact.gif" alt="picture" width="300" height="250" class="img">
 
                 </div>
-                <div class="accordion_element">
-                        <h2 class="accordion_text">CSS<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></h2>
+                <div class="accordion_element" id="aElement3">
+                        <a class="accordion_text" href="#aElement3">CSS<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
                         <span class="line"></span>
                         <img src="https://media.tenor.com/57w9du3NrV0AAAAM/css-html.gif" alt="picture" alt="picture" width="300" height="250" class="img">
                 </div>
-                <div class="accordion_element">
-                        <h2 class="accordion_text">QA Developer Designer<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></h2>
+                <div class="accordion_element" id="aElement4">
+                        <a class="accordion_text" href="#aElement4">QA Developer Designer<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
                         <span class="line"></span>
                         <img src="https://media.tenor.com/CD5CJb7w_4IAAAAM/qa-smash.gif" alt="picture" width="300" height="250" class="img">
                 </div>
-                <div class="accordion_element">
-                        <h2 class="accordion_text">Senior Junior<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></h2>
+                <div class="accordion_element" id="aElement5">
+                        <a class="accordion_text" href="#aElement5">Senior Junior<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
                         <span class="line"></span>
                         <img src="https://media.tenor.com/7urvfYVarZYAAAAM/senior2junior-throwstone.gif" alt="picture" width="300" height="250" class="img">
                 </div>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
                 <span class="line"></span>
                 <div class="accordion_element" id="aElement1">
                         <a class="accordion_text" href="#aElement1">Developer Tester Client<div class="plus"><span class="lineUP" ></span><span class="lineDown" ></span></div></a>
-                        <img src="https://media.tenor.com/DsbHvWBb6VgAAAAC/programming-client.gif" alt="picture" alt="picture" class="img">
+                        <img src="https://media.tenor.com/DsbHvWBb6VgAAAAC/programming-client.gif" alt="picture" class="img">
                 </div>
                 <span class="line"></span>
                 <div class="accordion_element" id="aElement2">

--- a/index.html
+++ b/index.html
@@ -13,29 +13,29 @@
                 <h1 class="h1">CSS Bayan</h1>
                 <span class="line"></span>
                 <div class="accordion_element" id="aElement1">
-                        <a class="accordion_text" href="#aElement1">Developer Tester Client<div class="plus"><span class="lineUP" ></span><span class="lineDown" ></span></div></a>
-                        <img src="https://media.tenor.com/DsbHvWBb6VgAAAAC/programming-client.gif" alt="picture" class="img">
+                        <a class="accordion_text" href="#aElement1">Defination of an Actual Strongest Man😃!<div class="plus"><span class="lineUP" ></span><span class="lineDown" ></span></div></a>
+                        <img src="https://dev-to-uploads.s3.amazonaws.com/uploads/articles/au2hlctns24mfc0l0egx.jpg" alt="picture" class="img">
                 </div>
                 <span class="line"></span>
                 <div class="accordion_element" id="aElement2">
-                        <a class="accordion_text" href="#aElement2">Programmer Bug<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
-                        <img src="https://media.tenor.com/w_mnvc7ulu8AAAAM/scaler-create-impact.gif" alt="picture" class="img">
+                        <a class="accordion_text" href="#aElement2">The All in One Solution😃!<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
+                        <img src="https://dev-to-uploads.s3.amazonaws.com/uploads/articles/jbbv8nbpun26xj7l30hk.png" alt="picture" class="img">
 
                 </div>
                 <span class="line"></span>
                 <div class="accordion_element" id="aElement3">
-                        <a class="accordion_text" href="#aElement3">CSS<div class="plus"><span class="lineUP" id="up"></span><span class="lineDown" id="down"></span></div></a>
-                        <img src="https://media.tenor.com/57w9du3NrV0AAAAM/css-html.gif" alt="picture" alt="picture" class="img">
+                        <a class="accordion_text" href="#aElement3">Once upon a Time with a Junior😃!<div class="plus"><span class="lineUP" id="up"></span><span class="lineDown" id="down"></span></div></a>
+                        <img src="https://dev-to-uploads.s3.amazonaws.com/uploads/articles/hm3vq072ldv4rsc76q1h.png" alt="picture" alt="picture" class="img">
                 </div>
                 <span class="line"></span>
                 <div class="accordion_element" id="aElement4">
-                        <a class="accordion_text" href="#aElement4">QA Developer Designer<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
-                        <img src="https://media.tenor.com/CD5CJb7w_4IAAAAM/qa-smash.gif" alt="picture" class="img">
+                        <a class="accordion_text" href="#aElement4">When you take every code seriously😃!<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
+                        <img src="https://dev-to-uploads.s3.amazonaws.com/uploads/articles/6a413tyi7awhnisccl62.jpg" alt="picture" class="img">
                 </div>
                 <span class="line"></span>
                 <div class="accordion_element" id="aElement5">
-                        <a class="accordion_text" href="#aElement5">Senior Junior<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
-                        <img src="https://media.tenor.com/7urvfYVarZYAAAAM/senior2junior-throwstone.gif" alt="picture" class="img">
+                        <a class="accordion_text" href="#aElement5">Use CSS in real<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
+                        <img src="https://i.redd.it/ns3t8yclaana1.png" alt="picture" class="img">
                 </div>
                 <span class="line"></span>
         </div>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,39 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" href="style.css">
         <title>Document</title>
 </head>
 <body>
-        
+        <div class="accordion_wrapper">
+                <h1 class="h1">CSS Bayan</h1>
+                <span class="line"></span>
+                <div class="accordion_element" id="test1">
+                        <a class="accordion_text" href="#test1">Developer Tester Client<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
+                        <span class="line"></span>
+                        <img src="https://media.tenor.com/DsbHvWBb6VgAAAAC/programming-client.gif" alt="picture" alt="picture" width="300" height="250" class="img">
+                </div>
+                <div class="accordion_element" id="test2">
+                        <a class="accordion_text" href="#test2">Programmer Bug<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></a>
+                        <span class="line"></span>
+                        <img src="https://media.tenor.com/w_mnvc7ulu8AAAAM/scaler-create-impact.gif" alt="picture" width="300" height="250" class="img">
+
+                </div>
+                <div class="accordion_element">
+                        <h2 class="accordion_text">CSS<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></h2>
+                        <span class="line"></span>
+                        <img src="https://media.tenor.com/57w9du3NrV0AAAAM/css-html.gif" alt="picture" alt="picture" width="300" height="250" class="img">
+                </div>
+                <div class="accordion_element">
+                        <h2 class="accordion_text">QA Developer Designer<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></h2>
+                        <span class="line"></span>
+                        <img src="https://media.tenor.com/CD5CJb7w_4IAAAAM/qa-smash.gif" alt="picture" width="300" height="250" class="img">
+                </div>
+                <div class="accordion_element">
+                        <h2 class="accordion_text">Senior Junior<div class="plus"><span class="lineUP"></span><span class="lineDown"></span></div></h2>
+                        <span class="line"></span>
+                        <img src="https://media.tenor.com/7urvfYVarZYAAAAM/senior2junior-throwstone.gif" alt="picture" width="300" height="250" class="img">
+                </div>
+        </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,71 @@
+.accordion_wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: left;
+  margin: 0;
+  padding: 0;
+}
+
+.accordion_wrapper:target .h1{
+color: red;
+}
+
+.line {
+  width: 300px;
+  border: solid 1px gray;
+  display: flex;
+  flex-direction: row;
+  opacity: 0.2;
+}
+
+.img {
+height: 0;
+}
+
+/* .accordion_element:hover .img{ 
+  height: 250px;
+  transition: all 0.7s;
+  } */
+
+a {
+  width: 300px;
+}
+
+.plus {
+  display: flex;
+  width: 11px;
+  height: 11px;
+}
+
+.lineUP {
+  border: solid 1px black;
+  transform: translateX(1.5px);
+
+}
+.lineDown {
+  border: solid 1px black;
+  transform: rotate(90deg);
+}
+
+.accordion_text {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.accordion_element:target .img {
+height: 250px;
+transition: all 0.3s;
+}
+
+.accordion_element:target .accordion_text .plus {
+  transform: rotate(90deg);
+  transition: all 0.5s;
+  }
+
+  .accordion_element:target .accordion_text .plus {
+    transform: rotate(45deg);
+    transition: all 0.5s;
+    }

--- a/style.css
+++ b/style.css
@@ -7,10 +7,6 @@
   padding: 0;
 }
 
-.accordion_wrapper:target .h1{
-color: red;
-}
-
 .line {
   max-width: 300px;
   border: solid 1px gray;
@@ -20,14 +16,9 @@ color: red;
 }
 
 .img {
-height: 0;
-max-width: 150px;
+  height: 0;
+  max-width: 150px;
 }
-
-/* .accordion_element:hover .img{ 
-  height: 250px;
-  transition: all 0.7s;
-  } */
 
 a {
   width: 300px;
@@ -37,6 +28,7 @@ a {
   display: flex;
   width: 11px;
   height: 11px;
+  opacity: 0;
 }
 
 .lineUP {
@@ -44,6 +36,7 @@ a {
   transform: translateX(1.5px);
   border-radius: 10px;
 }
+
 .lineDown {
   border: solid 1px rgb(0, 0, 0);
   transform: rotate(90deg);
@@ -60,24 +53,32 @@ a {
 }
 
 .accordion_element:target .img {
-height: 125px;
-transition: all 0.3s;
+  height: 125px;
+  transition: all 0.3s;
 }
 
 .accordion_element:target .accordion_text .plus {
   transform: rotate(90deg);
   transition: all 0.5s;
-  }
+}
 
-  .accordion_element:target .accordion_text .plus {
-    transform: rotate(45deg);
-    transition: all 0.5s;
-    }
+.accordion_element:target .accordion_text .plus {
+  transform: rotate(45deg);
+  transition: all 0.5s;
+}
 
-  .accordion_hover:hover .accordion_text{
+#aElement1:target .accordion_element {
+  transition: all 0.5s;
+}
+
+.accordion_hover:hover .accordion_text {
   color: rgb(0, 0, 0);
 }
 
+.accordion_hover:hover .accordion_text .plus {
+opacity: 1;
+transition: all 0.1s;
+}
 
 .accordion_element {
   display: flex;
@@ -87,9 +88,50 @@ transition: all 0.3s;
 
 .accordion_element:target .accordion_text {
   color: black;
-  }
+}
 
-  .accordion_element:target .accordion_text .plus {
-    transform: rotate(90deg);
-    transition: all 0.5s;
-    }
+.accordion_element:not(:target):hover .img {
+  height: 125px;
+  transition: all 0.3s;
+}
+
+.accordion_element:not(:target):hover .accordion_text .plus {
+  transform: rotate(45deg);
+  transition: all 0.5s;
+}
+
+#aElement1  {
+  cursor: pointer;
+}
+#aElement2 {
+  cursor: pointer;
+}
+#aElement3 {
+  cursor: pointer;
+}
+#aElement4 {
+  cursor: pointer;
+}
+#aElement5 {
+  cursor: pointer;
+}
+
+#aElement1:active  {
+  cursor: wait;
+}
+#aElement2:active  {
+  cursor: wait;
+}
+#aElement3:active  {
+  cursor: wait;
+}
+#aElement4:active  {
+  cursor: wait;
+}
+#aElement5:active  {
+  cursor: wait;
+}
+
+.accordion_wrapper {
+  font-family:fantasy;
+}

--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ color: red;
 }
 
 .line {
-  width: 300px;
+  max-width: 300px;
   border: solid 1px gray;
   display: flex;
   flex-direction: row;
@@ -21,6 +21,7 @@ color: red;
 
 .img {
 height: 0;
+max-width: 150px;
 }
 
 /* .accordion_element:hover .img{ 
@@ -39,13 +40,14 @@ a {
 }
 
 .lineUP {
-  border: solid 1px black;
+  border: solid 1px rgb(0, 0, 0);
   transform: translateX(1.5px);
-
+  border-radius: 10px;
 }
 .lineDown {
-  border: solid 1px black;
+  border: solid 1px rgb(0, 0, 0);
   transform: rotate(90deg);
+  border-radius: 10px;
 }
 
 .accordion_text {
@@ -53,10 +55,12 @@ a {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  text-decoration: none;
+  color: rgb(14, 25, 234);
 }
 
 .accordion_element:target .img {
-height: 250px;
+height: 125px;
 transition: all 0.3s;
 }
 
@@ -67,5 +71,25 @@ transition: all 0.3s;
 
   .accordion_element:target .accordion_text .plus {
     transform: rotate(45deg);
+    transition: all 0.5s;
+    }
+
+  .accordion_hover:hover .accordion_text{
+  color: rgb(0, 0, 0);
+}
+
+
+.accordion_element {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.accordion_element:target .accordion_text {
+  color: black;
+  }
+
+  .accordion_element:target .accordion_text .plus {
+    transform: rotate(90deg);
     transition: all 0.5s;
     }

--- a/style.css
+++ b/style.css
@@ -8,39 +8,40 @@
 }
 
 .line {
-  max-width: 300px;
-  border: solid 1px gray;
+  max-width: 100%;
+  border: solid 0.063rem gray;
   display: flex;
   flex-direction: row;
   opacity: 0.2;
+  margin: 0.938rem 0;
 }
 
 .img {
   height: 0;
-  max-width: 150px;
+  max-width: 64vh;
 }
 
 a {
-  width: 300px;
+  width: 112.5vh;
 }
 
 .plus {
   display: flex;
-  width: 11px;
-  height: 11px;
+  width: 2rem;
+  height: 2rem;
   opacity: 0;
 }
 
 .lineUP {
-  border: solid 1px rgb(0, 0, 0);
-  transform: translateX(1.5px);
-  border-radius: 10px;
+  border: solid 2px rgb(0, 0, 0);
+  transform: translateX(3.5px);
+  border-radius: 0.625rem;
 }
 
 .lineDown {
-  border: solid 1px rgb(0, 0, 0);
+  border: solid 2px rgb(0, 0, 0);
   transform: rotate(90deg);
-  border-radius: 10px;
+  border-radius: 0.625rem;
 }
 
 .accordion_text {
@@ -53,7 +54,7 @@ a {
 }
 
 .accordion_element:target .img {
-  height: 125px;
+  height: 53.3vh;
   transition: all 0.3s;
 }
 
@@ -91,8 +92,8 @@ transition: all 0.1s;
 }
 
 .accordion_element:not(:target):hover .img {
-  height: 125px;
-  transition: all 0.3s;
+  height: 31.252rem;
+  transition: all 0.5s;
 }
 
 .accordion_element:not(:target):hover .accordion_text .plus {
@@ -134,4 +135,64 @@ transition: all 0.1s;
 
 .accordion_wrapper {
   font-family:fantasy;
+  font-size: 2rem;
+}
+
+
+@media (max-width: 1150px) {
+  .accordion_wrapper {
+    font-size: 1.5rem;
+  }
+  a {
+    max-width: 55.25rem;
+  }
+  .img {
+    max-width: 58.5rem;
+    max-height: 58.5rem;
+  }
+  }
+
+@media (max-width: 920px) {
+  .accordion_wrapper {
+    font-size: 1rem;
+  }
+  a {
+    max-width: 31.25rem;
+  }
+  .img {
+    max-width: 31.5rem;
+    max-height: 31.5rem;
+  }
+  .plus {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 510px) {
+  .accordion_wrapper {
+    font-size: 1rem;
+  }
+  a {
+    max-width: 19.25rem;
+  }
+  .img {
+    max-width: 19.5rem;
+    max-height: 19.5rem;
+  }
+  .plus {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 320px) {
+  .accordion_wrapper {
+    font-size: 1rem;
+  }
+  .plus {
+    width: 1rem;
+    height: 1rem;
+  }
+    .plus {
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
1. Task: https://github.com/DrDiman/CSS-Bayan-task
2. Screenshot:
   ![image](https://user-images.githubusercontent.com/106424607/224559992-e260158b-1c8c-43b0-9396-42b1a2430fb7.png)
3. Deploy: https://rockatez.github.io/cssBayan/
4. Done 12.03.2023 / deadline 13.03.2023
5. Score: 128.5
Everything is done from Repository requirements and how to submit task section +30
The accordion component is centered on the screen, with equal indents on the left and right +10
Icons, meme texts and meme images are exist +5
Placement of the meme, icons and meme text are the same as in provided example gif images +5
Smooth change (transition) of the meme images and icons is done +20
Responsive design with three breakpoints for mobile, tablet, and desktop exist. Accordion is displayed correctly at mobile 320x568, tablet 820x1180, desktop 1920×1080. (Note: breakpoints don't have to be 320x568, 820x1180, 1920x1080). +10
All visual effects when the cursor is hovering over the memes, when the mouse is down on a meme, and when a meme is selected are implemented +10
The entire row (text, icon, and meme image) clickable +2.5
Cursor over the memes (hover) effect only exists for devices that can support hover. +10
The cursor when it is hovering over the rows of the accordion is changing +5
Only flexible dimensions are used rem, em, %, vh, vw, fr and etc... The accordion is responsive +10
All blocks/parts of the accordion are in base flow of the dom elements. All elements are not positioned with top, left, right, bottom. float is not used. The value of position is only static = 0
Pseudo-elements are not used (note 1: pseudo-classes are allowed; note 2: pseudo-elements only from FontAwesome are allowed) +5
Initially, the first meme should be expanded = 0
Font size is changed at each device (mobile, tablet, desktop) +5